### PR TITLE
Allows the use of f64 precision via feature flags and conditional compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "dubins_paths"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "criterion",
  "glam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dubins_paths"
-version = "2.4.2"
+version = "2.5.0"
 authors = ["VirxEC"]
 edition = "2021"
 description = "Rust code for calculating Dubin's Paths"
@@ -19,6 +19,9 @@ rand = "0.9.0"
 
 [dependencies]
 glam = { version = "0.29.2", optional = true }
+
+[features]
+f64 = []
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ DubinsPath has many methods you should look into, such as length, extract_subpat
 ## Features
 
 * `glam` - Use a [`glam`](https://crates.io/crates/glam) compatible API
+* `f64` - By default, the library uses `f32` precision and the equivalent `glam::f32` structs if that feature is enabled. Setting `f64` changes all numbers to 64-bit precision, and uses `glam::f64` vector types
 
 ## More documentation
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,15 @@ I've ported the code to Rust and documented everything that I could understand. 
 ## Quick example
 
 ```rust
-use core::f32::consts::PI;
-use dubins_paths::{DubinsPath, PosRot, Result as DubinsResult};
+use dubins_paths::{DubinsPath, PI, PosRot, Result as DubinsResult};
 
 // PosRot represents the car's (Pos)ition and (Rot)ation
 // Where x and y are the coordinates on a 2d plane
 // and theta is the orientation of the car's front in radians
 
 // The starting position and rotation
-// PosRot::from_f32 can also be used for const contexts
-const q0: PosRot = PosRot::from_f32(0., 0., PI / 4.);
+// PosRot::from_floats can also be used for const contexts
+const q0: PosRot = PosRot::from_floats(0., 0., PI / 4.);
 
 // The target end position and rotation
 // PosRot implements From<[f32; 3]>
@@ -29,7 +28,7 @@ let q1 = [100., -100., PI * (3. / 4.)].into();
 // The car's turning radius (must be > 0)
 // This can be calculated by taking a cars angular velocity and dividing it by the car's forward velocity
 // `turn radius = ang_vel / forward_vel`
-let rho: f32 = 11.6;
+let rho = 11.6;
 
 // Calculate the shortest possible path between these two points with the given turning radius
 let shortest_path_possible: DubinsResult<DubinsPath> = DubinsPath::shortest_from(q0, q1, rho);

--- a/benches/bench_dubins.rs
+++ b/benches/bench_dubins.rs
@@ -1,11 +1,11 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use dubins_paths::{DubinsPath, PathType, PosRot};
+use dubins_paths::{DubinsPath, FloatType, PathType, PosRot, PI};
 
-const TURN_RADIUS: f32 = 1. / 0.00076;
+const TURN_RADIUS: FloatType = 1. / 0.00076;
 
 fn setup_benchmark() -> (PosRot, PosRot) {
     let q0: PosRot = [2000., 2000., 0.].into();
-    let q1: PosRot = [0., 0., std::f32::consts::PI].into();
+    let q1: PosRot = [0., 0., PI].into();
     (q0, q1)
 }
 
@@ -44,7 +44,7 @@ fn bench_shortest_path(c: &mut Criterion) {
 }
 
 fn bench_many_sample(c: &mut Criterion) {
-    const STEP_DISTANCE: f32 = 10.;
+    const STEP_DISTANCE: FloatType = 10.;
     let (q0, q1) = setup_benchmark();
     let path = DubinsPath::shortest_from(q0, q1, TURN_RADIUS).unwrap();
 

--- a/examples/flamegraph.rs
+++ b/examples/flamegraph.rs
@@ -1,36 +1,38 @@
 #![allow(clippy::incompatible_msrv)]
 
-use core::{f32::consts::PI, hint::black_box};
+use core::hint::black_box;
 
-use dubins_paths::DubinsPath;
+use dubins_paths::{DubinsPath, FloatType, PI};
 use rand::Rng;
 
 fn main() {
     let runs = 1_000_000;
+    let range: FloatType = 10000.0;
 
     let mut thread_rng = rand::rng();
 
     for _ in 0..runs {
         let q0 = [
-            thread_rng.random_range(-10000_f32..10000.),
-            thread_rng.random_range(-10000_f32..10000.),
-            thread_rng.random_range((-2. * PI)..(2. * PI)),
+            thread_rng.random_range(-range..range),
+            thread_rng.random_range(-range..range),
+            thread_rng.random_range((-2. as FloatType * PI)..(2. as FloatType * PI)),
         ]
         .into();
         let q1 = [
-            thread_rng.random_range(-10000_f32..10000.),
-            thread_rng.random_range(-10000_f32..10000.),
-            thread_rng.random_range((-2. * PI)..(2. * PI)),
+            thread_rng.random_range(-range..range),
+            thread_rng.random_range(-range..range),
+            thread_rng.random_range((-2. as FloatType * PI)..(2. as FloatType * PI)),
         ]
         .into();
 
-        let rho = thread_rng.random_range(600f32..3000.);
+        let rho = thread_rng.random_range((600.0 as FloatType)..(3000. as FloatType));
 
         let Ok(path) = DubinsPath::shortest_from(black_box(q0), q1, rho) else {
             continue;
         };
 
-        let step_distance = thread_rng.random_range(5f32..(rho / 100.));
+        let step_distance =
+            thread_rng.random_range((5.0 as FloatType)..(rho / (100.0 as FloatType)));
         let _ = path.sample_many(black_box(step_distance));
     }
 }


### PR DESCRIPTION
# Changes

- Adds f64 support via a feature flag on the crate
- Deprecates the `from_f32` method for PosRot as this is now misleading
- Adds `from_floats` as a more generically named method
- Updates documentation and tests

# Info 

We need a Rust lib that does Dubins for high precision geospatial work. I've used the reference Andrew Walker C lib for some time before, and that is all in 64 bit doubles. 

To preserve whats here with minimal breakage, I've added in a feature flag that sets the precision of the library via conditional compilation of some type aliases. By default its `f32` - so anything still using that API should not break - indeed there should be no changes. 

I have added in a deprecation for the method `from_f32` primarily as that now would be rather misleading for an f64 user - and having some reusable code wouldn't work nicely with an `from_f64` method. I went with a more generic `from_floats` method. Thats' my opinion - happy for @VirxEC to do what you please there. 

Docs have had some `f32` explicit specifiers removed in some cases where type deduction can figure it out. All docs tests passed with 4x combos of `glam` and `f64` feature flags enabled. 

We also export a public `PI` value if required - I would expect thats mainly more of a convenience for test and docs code than anything I would actually use in a real-world application (ie: my geospatial tool will never need `f32::PI` - I'd import `f64::PI`  more explicitly)

I have also bumped the version to `2.5.0` in the PR for the purposes of testing that deprecation - again happy for @VirxEC to do what they think they should for that version bump. I would not expect this to be 3.0.0 as it doesn't change anything if you don't add the new feature flag. 

Feedback welcome! Thanks for porting the Andrew Walker lib 

