### PR TITLE
Changes logic on sampling a full curve with a length under the sampling distance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,20 +919,31 @@ impl DubinsPath {
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let num_samples = ((end - start) / step_distance).floor() as u32;
 
-        let mut samples: Vec<_> = (0..num_samples)
-            .map(|i| {
-                // Since the value originally comes from FloatType,
-                // this should be fine
-                #[allow(clippy::cast_precision_loss)]
-                #[allow(clippy::cast_lossless)]
-                (i as FloatType * step_distance + start)
-            })
-            .map(|t| self.sample_cached(t, types, qi, q1, q2))
-            .collect();
+        let samples = if num_samples == 0 && includes_end {
+            // If the num of samples we have specified here floors to 0 - we return a degenerate straight line if includes_end is true
+            // This should cover full "interpolation" of curves with a distance close or under the sampling value
+            vec![
+                self.sample_cached(0.0, types, qi, q1, q2),
+                self.sample_cached(end, types, qi, q1, q2),
+            ]
+        } else {
+            let mut samples: Vec<_> = (0..num_samples)
+                .map(|i| {
+                    // Since the value originally comes from FloatType,
+                    // this should be fine
+                    #[allow(clippy::cast_precision_loss)]
+                    #[allow(clippy::cast_lossless)]
+                    (i as FloatType * step_distance + start)
+                })
+                .map(|t| self.sample_cached(t, types, qi, q1, q2))
+                .collect();
 
-        if includes_end {
-            samples.push(self.sample_cached(end, types, qi, q1, q2));
-        }
+            if includes_end {
+                samples.push(self.sample_cached(end, types, qi, q1, q2));
+            }
+
+            samples
+        };
 
         samples
     }
@@ -1168,5 +1179,22 @@ mod tests {
         );
         assert_eq!(path.sample_many_range(step_distance, zero..).len(), 38);
         assert_eq!(path.sample_many_range(step_distance, ..).len(), 38);
+    }
+
+    #[test]
+    fn sample_many_small_interpolation() {
+        // Tests a small real case of a curve with a distance less than the interpolation/sampling distance
+        // In this case - we should see a degenerate "straight line" as the result
+        let path = DubinsPath {
+            qi: PosRot([567105.33225801913, 6909411.6672947491, 1.6033922771475371]),
+            rho: 4.1230259079368361,
+            param: [0.05386957718771157, 0.23210650646903627, 0.43365728520008034],
+            path_type: PathType::LSL
+        };
+
+        let sample_distance = 3.0;
+        assert!(path.length() < sample_distance);
+        let sampled  = path.sample_many(sample_distance);
+        assert!(sampled.len() == 2);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1186,13 +1186,17 @@ mod tests {
         let path = DubinsPath {
             qi,
             rho: 4.1230259079368361,
-            param: [0.05386957718771157, 0.23210650646903627, 0.43365728520008034],
-            path_type: PathType::LSL
+            param: [
+                0.05386957718771157,
+                0.23210650646903627,
+                0.43365728520008034,
+            ],
+            path_type: PathType::LSL,
         };
 
         let sample_distance = 3.0;
         assert!(path.length() < sample_distance);
-        let sampled  = path.sample_many(sample_distance);
+        let sampled = path.sample_many(sample_distance);
         assert!(sampled.len() == 2);
     }
 }


### PR DESCRIPTION
I saw another few little oddities in the Dubins lib and thought I'd push this up. 

When you have a curve with a length < the sampling distance - you end up with an ambiguous result. 

I would expect that when you call `sample_many` - you would receive back at least 2x points
 - guaranteed one for the curve start 
 - guaranteed one for the curve end 
 - and as many interpolation points as you can fit in between

Have added a test in there too based on the original data I caught this with. 